### PR TITLE
Clean up HttpResourceActor

### DIFF
--- a/common/src/main/scala/com/paypal/cascade/common/seq/seq.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/seq/seq.scala
@@ -34,7 +34,7 @@ package object seq {
      */
     def get(i: Int): Option[T] = {
       if(i >= 0 && i < seq.length) {
-        Some(seq.apply(i))
+        Some(seq(i))
       } else {
         None
       }

--- a/doc/HTTP_RESOURCE_GETTING_STARTED.md
+++ b/doc/HTTP_RESOURCE_GETTING_STARTED.md
@@ -93,6 +93,4 @@ One final note - make sure your `MyServer` object extends `CascadeApp`. Doing
 so will set up some global logging and exception handling features that work
 best with Spray/Akka servers.
 
-See the
-[example `ServerModule`](/examples/src/main/scala/com/paypal/cascade/examples/http/resource/MyHttpServerModule.scala)
-for working code.
+See the [example http server](examples/src/main/scala/com/paypal/cascade/examples/http/resource/MyHttpServer.scala) for working code.

--- a/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
@@ -20,7 +20,6 @@ import akka.actor.{Status, Actor}
 import com.paypal.cascade.common.option._
 import com.paypal.cascade.http.util.HttpUtil
 import com.paypal.cascade.json._
-import akka.event.LoggingReceive
 import scala.compat.Platform._
 import scala.util.{Success, Failure}
 import spray.http.HttpResponse
@@ -36,7 +35,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
   /**
    * The receive function for this resource. Should not be overridden - implement [[resourceReceive]] instead
    */
-  override final def receive: Actor.Receive = LoggingReceive {
+  override final def receive: Actor.Receive = {
     super.receive orElse resourceReceive orElse failureReceive
   }
 
@@ -66,7 +65,6 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    * @param t the error that occurred
    */
   private def handleUnexpectedRequestError(t: Throwable): Unit = {
-    setNextStep[HttpResponse]
     log.warning("Unexpected request error: {} , cause: {}, trace: {}", t.getMessage, t.getCause, t.getStackTrace.mkString("", EOL, EOL))
     t match {
       case e: Exception =>

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -140,7 +140,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
       val processRequest = for {
         _ <- Try(before(request.method))
         _ <- ensureContentTypeSupportedAndAcceptable
-        req <- resourceContext.reqParser.apply(request).map(ProcessRequest)
+        req <- resourceContext.reqParser(request).map(ProcessRequest)
       } yield req
       processRequest.foreach { _ =>
         //account for extremely long processing times
@@ -242,7 +242,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
         if (headers.exists(_.lowercaseName == HttpUtil.CONTENT_LANGUAGE_LC)) {
           headers
         } else {
-          RawHeader(HttpUtil.CONTENT_LANGUAGE, lang.toString()) :: headers
+          RawHeader(HttpUtil.CONTENT_LANGUAGE, lang.toString) :: headers
         }
       case None => headers
     }

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/resource.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/resource.scala
@@ -18,8 +18,7 @@ package com.paypal.cascade.http.tests
 import spray.http.{HttpResponse, HttpRequest}
 import com.paypal.cascade.http.resource.{HttpResourceActor, ResourceDriver, AbstractResourceActor}
 import scala.concurrent.Future
-import scala.util.Try
-import akka.actor.{Props, ActorRef, ActorSystem}
+import akka.actor.ActorSystem
 import com.paypal.cascade.http.resource.HttpResourceActor.ResourceContext
 
 package object resource {


### PR DESCRIPTION
Summary of changes:
* Reduces the maximum number of messages passed from seven to four
* Removes the need to track the pending step
* Fixes a broken link in the docs