### PR TITLE
using travis caching on the ivy cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ scala:
   - 2.11.5
 
 sudo: false
+
+cache:
+  directories:
+    - $HOME/.ivy2

--- a/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
@@ -76,6 +76,7 @@ object SprayActor {
       interface = "0.0.0.0",
       port = sprayConfig.port,
       backlog = sprayConfig.backlog)
+
     (AkkaIO(Http) ? bindMsg).mapTo[Http.Event]
   }
 }


### PR DESCRIPTION
@taylorleese please review.

the [travis-ci caching docs](http://docs.travis-ci.com/user/caching/#Arbitrary-directories) show an example for caching the `~/.m2` directory, so I think this could work with `~/.ivy2` too.