### PR TITLE
Fix JDK 8 bug in AbstractResourceActorSpecs

### DIFF
--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/AbstractResourceActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/AbstractResourceActorSpecs.scala
@@ -69,7 +69,7 @@ class AbstractResourceActorSpecs
        */
       override protected def resourceReceive: PartialFunction[Any, Unit] = {
         case ProcessRequest("json") => completeToJSON(OK, PongResponse("pong"))
-        case ProcessRequest("badjson") => completeToJSON(OK, testActor) //trying to serialize something we shouldn't
+        case ProcessRequest("badjson") => completeToJSON(OK, SourObject) //trying to serialize something we shouldn't
         case ProcessRequest("error") => sendError(GenericException)
         case ProcessRequest("errorCode") => sendErrorCodeResponse(InternalServerError)
         case ProcessRequest("errorResponse") => sendErrorResponse(InternalServerError, ErrorResponse("oops"))
@@ -94,6 +94,11 @@ class AbstractResourceActorSpecs
 
     case object GenericException extends Exception("generic downstream exception")
     case object CustomException extends Exception("this is a custom exception")
+    object SourObject {
+      lazy val thisWillThrow = {
+        throw new RuntimeException("accessor throws an exception, and Jackson will respond with a failure")
+      }
+    }
   }
 
   case class test() extends Context {


### PR DESCRIPTION
This test's aim was to test trying to serialize something that shouldn't be serialized, but it underestimated Jackson's ability to serialize just about anything. Unfortunately, sometimes objects have cyclical references, as `testActor` does (at least, in Scala 2.11.4.)

I can't be 100% sure, but I think that in JDK 8, there's just enough of a difference in how `StackOverflowError`s are handled by the JRE that [this code](https://github.com/FasterXML/jackson-databind/blob/2.4/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java#L648-L657) had the potential to miss its opportunity to run. So, this test was in a very delicate state whereby one too few available stack frames could break everything.

An easier way to provide an object that can't be serialized is to make it literally impossible to [call one of its accessors](https://github.com/FasterXML/jackson-databind/blob/2.4/src/main/java/com/fasterxml/jackson/databind/ser/BeanPropertyWriter.java#L466) without incident. Hence, this PR defines a simple object with one `lazy val` member that throws a `RuntimeException` when it's evaluated. When Jackson goes to serialize it, that exception will be thrown and eventually the `.toJson` try will fail, and you'll get the correct response.

Resolves #80