### PR TITLE
Remove sequentialExecutionContext

### DIFF
--- a/common/src/main/scala/com/paypal/cascade/common/future/future.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/future/future.scala
@@ -16,27 +16,11 @@
 package com.paypal.cascade.common
 
 import scala.concurrent._
-import org.slf4j.Logger
 
 /**
  * Convenience methods and implicits for working with Futures.
  */
 package object future {
-
-  /**
-   * An [[scala.concurrent.ExecutionContext]] that runs tasks immediately, and logs errors to the given logger.
-   * This context is useful for mapping functions that are cheap to compute (ie: simple transformations, etc)
-   * @param logger the logger to which to log errors
-   * @return the new [[scala.concurrent.ExecutionContext]]
-   */
-  def sequentialExecutionContext(logger: Logger): ExecutionContext = new ExecutionContext {
-    override def reportFailure(t: Throwable): Unit = {
-      logger.error(t.getMessage, t)
-    }
-    override def execute(runnable: Runnable): Unit = {
-      runnable.run()
-    }
-  }
 
   /**
    * Implicits to provide slightly cleaner patterns for handling Futures

--- a/common/src/test/scala/com/paypal/cascade/common/tests/future/FutureSpecs.scala
+++ b/common/src/test/scala/com/paypal/cascade/common/tests/future/FutureSpecs.scala
@@ -19,12 +19,11 @@ import org.specs2._
 import scala.concurrent.ExecutionContext
 import com.paypal.cascade.common.future._
 import scala.concurrent.Future
-import com.paypal.cascade.common.logging.LoggingSugar
 
 /**
  * Tests implicit classes in [[com.paypal.cascade.common.future]]
  */
-class FutureSpecs extends Specification with ScalaCheck with LoggingSugar { def is=s2"""
+class FutureSpecs extends Specification with ScalaCheck { def is=s2"""
 
   mapFailure:
 
@@ -36,7 +35,7 @@ class FutureSpecs extends Specification with ScalaCheck with LoggingSugar { def 
     Converts a failed Future[T] to Future[Unit]                               ${FutureToUnit().failed}
 
 """
-  implicit val ec: ExecutionContext = sequentialExecutionContext(getLogger[FutureSpecs])
+
   case class CustomException(message: String) extends Exception(message)
 
   case class FutureMapFailure() {


### PR DESCRIPTION
Remove ```sequentialExecutionContext``` because we shouldn't encourage it's usage and the ```CallingThreadDispatcher``` can achieve the same thing in tests.