### PR TITLE
More reliable resource timeouts

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
@@ -57,7 +57,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    */
   private def failureReceive: Actor.Receive = {
     case s @ Status.Failure(t: Throwable) =>
-      handleUnexpectedRequestError(t)
+      handleRequestError(t)
   }
 
   /**
@@ -65,7 +65,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    * send the exception to returnActor and stop.
    * @param t the error that occurred
    */
-  private def handleUnexpectedRequestError(t: Throwable): Unit = {
+  private def handleRequestError(t: Throwable): Unit = {
     t match {
       case e: Exception => handleHttpResponse(createErrorResponse(e))
       case t: Throwable => throw t
@@ -89,7 +89,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
   protected final def completeToJSON[T](code: StatusCode, response: T): Unit = {
     response.toJson.orErrorWithMessage(t => s"Could not write response to json: ${t.getClass.getSimpleName}") match {
       case Success(jsonStr) => complete(HttpResponse(code, jsonStr))
-      case Failure(t) => handleUnexpectedRequestError(t)
+      case Failure(t) => handleRequestError(t)
     }
   }
 
@@ -103,7 +103,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
   protected final def completeToJSON[T](code: StatusCode, response: T, location: String): Unit = {
     response.toJson.orErrorWithMessage(t => s"Could not write response to json: ${t.getClass.getSimpleName}") match {
       case Success(jsonStr) => complete(HttpResponse(code, jsonStr), location)
-      case Failure(t) => handleUnexpectedRequestError(t)
+      case Failure(t) => handleRequestError(t)
     }
   }
 
@@ -122,7 +122,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    * @param f The error to be used for server response.
    */
   protected final def sendError(f: Throwable): Unit = {
-    handleUnexpectedRequestError(f)
+    handleRequestError(f)
   }
 
   /**
@@ -133,7 +133,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    * @tparam T Type of the error
    */
   protected final def sendErrorResponse[T : Manifest](code: StatusCode, error: T): Unit = {
-    handleUnexpectedRequestError(HaltException(code, HttpUtil.toJsonBody(error)))
+    handleRequestError(HaltException(code, HttpUtil.toJsonBody(error)))
   }
 
   /**
@@ -141,7 +141,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    * @param code The error code to return
    */
   protected final def sendErrorCodeResponse(code: StatusCode): Unit = {
-    handleUnexpectedRequestError(HaltException(code))
+    handleRequestError(HaltException(code))
   }
 
 }

--- a/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
@@ -67,7 +67,7 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
    */
   private def handleRequestError(t: Throwable): Unit = {
     t match {
-      case e: Exception => handleHttpResponse(createErrorResponse(e))
+      case e: Exception => completeRequest(createErrorResponse(e))
       case t: Throwable => throw t
     }
   }

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -189,7 +189,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
     //the actor didn't complete the request before the request timeout
     case RequestTimedOut =>
       log.error(s"Did not complete request within ${resourceContext.resourceTimeout}.")
-      handleHttpResponse(HttpResponse(StatusCodes.ServiceUnavailable))
+      handleHttpResponse(createErrorResponse(HaltException(StatusCodes.ServiceUnavailable)))
   }
 
   private[resource] def handleHttpResponse(r: HttpResponse): Unit = {

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -288,7 +288,7 @@ object HttpResourceActor {
   /* responses */
   /**
    * Used to notify the resource actor that the server has processed the request and can complete it
-   * @param response the resposne to send
+   * @param response the response to send
    * @param mbLocation optional location for the returned resource if something was created
    */
   private[resource] case class RequestIsProcessed(response: HttpResponse, mbLocation: Option[String])

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -258,7 +258,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
 }
 
 object HttpResourceActor {
-
+  /* requests */
   /**
    * Contains all information needed to start an HttpResourceActor.
    * @param reqContext the spray `spray.routing.RequestContext` for this request
@@ -274,26 +274,31 @@ object HttpResourceActor {
                              mbReturnActor: Option[ActorRef] = None,
                              resourceTimeout: FiniteDuration = HttpResourceActor.defaultResourceTimeout)
 
-  //requests
-  /**
-   * Sent to AbstractResourceActor to indicate that a request should be processed
-   * @param req The parsed request to process
-   */
-  case class ProcessRequest(req: Any)
-
-  //responses
-  case class RequestIsProcessed(response: HttpResponse, mbLocation: Option[String])
-
   /**
    * the function that parses an [[spray.http.HttpRequest]] into a type, or fails
    */
   type RequestParser = HttpRequest => Try[AnyRef]
 
   /**
+   * Sent to AbstractResourceActor to indicate that a request should be processed
+   * @param req The parsed request to process
+   */
+  case class ProcessRequest(req: Any)
+
+  /* responses */
+  /**
+   * Used to notify the resource actor that the server has processed the request and can complete it
+   * @param response the resposne to send
+   * @param mbLocation optional location for the returned resource if something was created
+   */
+  private[resource] case class RequestIsProcessed(response: HttpResponse, mbLocation: Option[String])
+
+  /**
    * the only message to send each `com.paypal.cascade.http.resource.HttpResourceActor`. it begins processing the
    * [[com.paypal.cascade.http.resource.AbstractResourceActor]] that it contains
    */
-  object Start
+  private[http] object Start
+
   /**
    * Signals that the request timed out.
    */

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -128,9 +128,6 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
    */
   private val request = resourceContext.reqContext.request
 
-  // we use the scheduler to enforce timeouts instead, see issue #92
-  context.setReceiveTimeout(Duration.Undefined)
-
   //crash on unhandled exceptions
   override val supervisorStrategy =
     OneForOneStrategy() {

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -126,12 +126,6 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
   /*
    * Internal
    */
-
-  /**
-   * Signals that the request timed out.
-   */
-  case object RequestTimedOut
-
   private val request = resourceContext.reqContext.request
 
   // we use the scheduler to enforce timeouts instead, see issue #92
@@ -194,7 +188,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
 
     //the actor didn't complete the request before the request timeout
     case RequestTimedOut =>
-      log.error(s"$self did not complete request within ${resourceContext.resourceTimeout}. Returning 503.")
+      log.error(s"Did not complete request within ${resourceContext.resourceTimeout}.")
       handleHttpResponse(HttpResponse(StatusCodes.ServiceUnavailable))
   }
 
@@ -300,6 +294,10 @@ object HttpResourceActor {
    * [[com.paypal.cascade.http.resource.AbstractResourceActor]] that it contains
    */
   object Start
+  /**
+   * Signals that the request timed out.
+   */
+  private case object RequestTimedOut
 
   /**
    * The default timeout for a request which is not completed in time. Not the same as spray's timeout.

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/DummyResource.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/DummyResource.scala
@@ -15,20 +15,17 @@
  */
 package com.paypal.cascade.http.tests.resource
 
-import spray.http._
-import StatusCodes._
 import scala.concurrent._
-import com.paypal.cascade.http.resource._
-import akka.actor.{Props, Actor}
-import com.paypal.cascade.http.tests.resource.DummyResource._
-import com.paypal.cascade.http.tests.resource.DummyResource.SleepRequest
-import com.paypal.cascade.http.tests.resource.DummyResource.PostRequest
-import com.paypal.cascade.http.resource.HttpResourceActor.ProcessRequest
-import com.paypal.cascade.http.tests.resource.DummyResource.GetRequest
-import spray.http.HttpResponse
-import com.paypal.cascade.http.tests.resource.DummyResource.LanguageRequest
+import scala.concurrent.duration._
+
+import akka.actor.Actor
 import spray.http.HttpHeaders.RawHeader
-import com.paypal.cascade.http.resource.HttpResourceActor.ResourceContext
+import spray.http.StatusCodes._
+import spray.http.{HttpResponse, _}
+
+import com.paypal.cascade.http.resource.HttpResourceActor.{ProcessRequest, ResourceContext}
+import com.paypal.cascade.http.resource._
+import com.paypal.cascade.http.tests.resource.DummyResource.{GetRequest, LanguageRequest, PostRequest, SleepRequest, _}
 
 /**
  * Dummy implementation of a Spray resource. Does not perform additional parsing of requests, expects a basic type
@@ -74,14 +71,7 @@ class DummyResource(requestContext: ResourceContext)
    * @param req request object
    */
   def doSleep(req: SleepRequest): Unit = {
-    //spawn an actor and sleep in there
-    class SleepActor extends Actor {
-      def receive: Actor.Receive = {
-        case SleepRequest(m) => Thread.sleep(m); sender ! FinishedSleeping()
-      }
-    }
-    val sleeper = context.actorOf(Props(classOf[SleepActor], this), "sleeper")
-    sleeper ! req
+    context.system.scheduler.scheduleOnce(req.millis.milliseconds, self, FinishedSleeping())
   }
 
   def doSyncSleep(req: SyncSleep): Unit = {

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/DummyResource.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/DummyResource.scala
@@ -119,7 +119,7 @@ class DummyResource(requestContext: ResourceContext)
     case ProcessRequest(req: SleepRequest) => doSleep(req)
     case ProcessRequest(req: SyncSleep) => doSyncSleep(req)
     //extra actor messages to respond to
-    case FinishedSleeping() => log.debug("finished sleeping"); complete(HttpResponse(OK, "pong"))
+    case FinishedSleeping() => log.info("finished sleeping"); complete(HttpResponse(OK, "pong"))
   }
 }
 

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
@@ -91,16 +91,6 @@ class HttpResourceActorSpecs
       started must beASuccessfulTry
     }
 
-    def timesOut = {
-      val refAndProbe = RefAndProbe(TestActorRef(new DummyResource(ResourceContext(dummyReqCtx, reqParser, None, Duration.Zero))))
-
-      val stoppedRes = refAndProbe must beStopped
-      val failedRes = reqCtxHandlerActorFuture.toTry must beASuccessfulTry.like {
-        case HttpResponse(status, _, _, _) => status must beEqualTo(StatusCodes.ServiceUnavailable)
-      }
-      stoppedRes and failedRes
-    }
-
     def timesOutOnAsyncRequestProcessor = {
       // this test results in a dead letter for the FinishedSleeping message if it passes. no big deal
       val veryShortTimeout = Duration(50, TimeUnit.MILLISECONDS)

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
@@ -103,13 +103,13 @@ class HttpResourceActorSpecs
 
     def timesOutOnAsyncRequestProcessor = {
       // this test results in a dead letter for the FinishedSleeping message if it passes. no big deal
-      val processRecvTimeout = Duration(50, TimeUnit.MILLISECONDS)
+      val veryShortTimeout = Duration(50, TimeUnit.MILLISECONDS)
 
       lazy val resourceActorCtor = new DummyResource(ResourceContext(
         reqContext = dummyReqCtx,
         reqParser = request => Success(SleepRequest(500)),
         mbReturnActor = None,
-        processRecvTimeout = processRecvTimeout
+        resourceTimeout = veryShortTimeout
       ))
       val refAndProbe = RefAndProbe(TestActorRef(resourceActorCtor))
       refAndProbe.ref ! HttpResourceActor.Start
@@ -120,13 +120,13 @@ class HttpResourceActorSpecs
 
     def timeOutFailsOnBlockingRequestProcessor = {
       // this test results in a dead letter for the timeout as a natural consequence of it blocking
-      val processRecvTimeout = Duration(50, TimeUnit.MILLISECONDS)
+      val veryShortTimeout = Duration(50, TimeUnit.MILLISECONDS)
 
       lazy val resourceActorCtor = new DummyResource(ResourceContext(
         reqContext = dummyReqCtx,
         reqParser = request => Success(SyncSleep(500)),
         mbReturnActor = None,
-        processRecvTimeout = processRecvTimeout
+        resourceTimeout = veryShortTimeout
       ))
       val refAndProbe = RefAndProbe(TestActorRef(resourceActorCtor))
       refAndProbe.ref ! HttpResourceActor.Start


### PR DESCRIPTION
Uses the Akka Scheduler to schedule a timeout message rather than relying on `receiveTimeout`, which could be circumvented by a child class receiving lots of errant messages but handling them in their `resourceReceive` method. The end result is that you are guaranteed to send the timeout message after the timeout period, rather than having other messages constantly preempt you. One drawback is that occasionally this can result in dead letters, especially if client code blocks, but I did my best to lower the possibility of them.

While you can always use the [spray timeout](http://spray.io/documentation/1.1-SNAPSHOT/spray-routing/key-concepts/timeout-handling/), this allows you to keep a per-request level of timeout.

Fixes #92.

## Additions

1. `HttpResourceActor` now has a `timeoutCancellable` which is a `protected final lazy val`. It gets initialized when the resource receives a `Start` message and is `cancel()`ed when `RequestIsProcessed` is received, or when the request is about to be completed if it wasn't through that success case. You can also manually cancel it in a child class, but you cannot override how it was declared.
2. `RequestTimedOut` – a case object used for the timeout message. It is private.

## Modifications

1. `recvTimeout` and `processRecvTimeout` have been unified into one value, `resourceTimeout`.
2. The akka `context.receiveTimeout` for `HttpResourceActor`s is now indefinite.
3. `Start` and `RequestIsProcessed` are now package private. They didn't need to be accessible to non-Cascade code.
4. The timeout response creates a `HaltException` with a 503 and sends it through `createErrorResponse` instead, so children of `HttpResourceActor` can change what they want their timeout message to be.
5. The test for timeouts in asynchronous computation has changed to also schedule a message instead of spinning up an actor. I found that the test would flap otherwise, and this is more concise and performant anyway. I suspect it has something to do with the test environment, but I'm not sure.

## Removals

1. `RequestIsParsed` was removed from `HttpResourceActor`. It wasn't used.
2. 3 tests in `HttpResourceActorSpecs` were removed. One was not being used at all, and the other two were redundant.