### PR TITLE
Restore Jackson exception matching

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
@@ -61,18 +61,6 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
   }
 
   /**
-   * There was an error somewhere along the way, so translate it to an HttpResponse (using createErrorResponse),
-   * send the exception to returnActor and stop.
-   * @param t the error that occurred
-   */
-  private def handleRequestError(t: Throwable): Unit = {
-    t match {
-      case e: Exception => completeRequest(createErrorResponse(e))
-      case t: Throwable => throw t
-    }
-  }
-
-  /**
    * Complete a successful request
    * @param resp The HttpResponse to be returned
    */

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -123,7 +123,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
 
   private def createHaltExceptionForResponse(exception: Exception): HaltException = exception match {
     case haltException: HaltException => haltException
-    case jsonException @ (_: JsonParseException | _:JsonMappingException) =>
+    case jsonException @ (_: JsonParseException | _: JsonMappingException) =>
       HaltException(BadRequest, s"Unable to parse request: ${jsonException.getClass.getSimpleName}")
     case otherException: Exception =>
       HaltException(InternalServerError, s"Error in request execution: ${otherException.getClass.getSimpleName}")

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
@@ -24,6 +24,7 @@ import scala.util.{Failure, Success, Try}
 import akka.actor.ActorSystem
 import akka.testkit.{TestActorRef, TestKit}
 import spray.http.{HttpMethod, HttpRequest, HttpResponse, StatusCodes}
+import com.fasterxml.jackson.core.{JsonLocation, JsonParseException}
 import org.specs2.SpecificationLike
 
 import com.paypal.cascade.akka.tests.actor.ActorSpecification
@@ -149,7 +150,7 @@ class HttpResourceActorSpecs
   }
 
   case class Fails() extends Context {
-    private lazy val ex = new Exception("hello world")
+    private lazy val ex = new JsonParseException("hello world", JsonLocation.NA)
     override protected lazy val reqParser: HttpResourceActor.RequestParser = { req: HttpRequest =>
       Failure(ex)
     }


### PR DESCRIPTION
While it looked nice to not have to match on the Jackson exceptions, I had failed to account for the desire to override the error which could occur when parsing the request.

It's kind of unfortunate that the alternative was to put the message in a protected method, which would have complicated the interface. Matching on the Jackson exceptions feels a little prescriptive, but making the `reqParser` return an `Either` that could type on the exception would probably be even more prescriptive. There's also the problem with these two exceptions happening internally, not for request parsing, but the response still being a 400.

At least this PR gets rid of the semantic weirdness around the `HttpResourceActor` sending itself a `Status.Failure` when its `receive` method doesn't have a case for it.