### PR TITLE
Configurable parse error message

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/AbstractResourceActor.scala
@@ -61,18 +61,6 @@ abstract class AbstractResourceActor(private val resourceContext: HttpResourceAc
   }
 
   /**
-   * There was an error somewhere along the way, so translate it to an HttpResponse (using createErrorResponse),
-   * send the exception to returnActor and stop.
-   * @param t the error that occurred
-   */
-  private def handleRequestError(t: Throwable): Unit = {
-    t match {
-      case e: Exception => completeRequest(createErrorResponse(e))
-      case t: Throwable => throw t
-    }
-  }
-
-  /**
    * Complete a successful request
    * @param resp The HttpResponse to be returned
    */

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -18,7 +18,7 @@ package com.paypal.cascade.http.resource
 import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.concurrent.duration._
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 import akka.actor.SupervisorStrategy.Escalate
 import akka.actor._
@@ -141,6 +141,18 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
       case _ => Escalate
     }
 
+  /**
+   * There was an error somewhere along the way, so translate it to an HttpResponse (using createErrorResponse),
+   * send the exception to returnActor and stop.
+   * @param t the error that occurred
+   */
+  private[http] final def handleRequestError(t: Throwable): Unit = {
+    t match {
+      case e: Exception => completeRequest(createErrorResponse(e))
+      case t: Throwable => throw t
+    }
+  }
+
   override def receive: Actor.Receive = { // scalastyle:ignore cyclomatic.complexity scalastyle:ignore method.length
 
     /*
@@ -156,7 +168,10 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
         _ <- ensureContentTypeSupportedAndAcceptable
         req <- resourceContext.reqParser(request).orHaltWithMessage(BadRequest)(parseErrorMessage).map(ProcessRequest)
       } yield req
-      self ! processRequest.orFailure
+      processRequest match {
+        case Success(proc) => self ! proc
+        case Failure(t) => handleRequestError(t)
+      }
 
     //the request has been processed, now construct the response, send it to the spray context, send it to the returnActor, and stop
     case RequestIsProcessed(resp, mbLocation) =>

--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -145,7 +145,9 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
    * There was an error somewhere along the way, so translate it to an HttpResponse (using createErrorResponse),
    * send the exception to returnActor and stop.
    * @param t the error that occurred
+   * @throws Throwable if t is not of type `Exception`
    */
+  @throws[Throwable]
   private[http] final def handleRequestError(t: Throwable): Unit = {
     t match {
       case e: Exception => completeRequest(createErrorResponse(e))


### PR DESCRIPTION
In my recent changes I accidentally made it so that you could not override the error message upon `reqParser` failing to parse. This adds a method `parseErrorMessage` which provides that message and can be overridden.

Initially I had taken the approach in #100 but it didn't feel right. For instance, some of the Jackson exceptions that were going to be handled in `createErrorResponse` again could mistakenly return a 400 for what should have been a 500 in a serialization failure. There are other problems with us not treating serialization failures correctly. See #101. But this PR just takes care of this message not being changeable by the downstream client.

This PR also gets rid of the semantic weirdness around the HttpResourceActor sending itself a Status.Failure when its receive method doesn't have a case for it.