### PR TITLE
Stop requiring charset in Content-Type

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/resource/HttpResourceActor.scala
@@ -64,7 +64,7 @@ private[http] abstract class HttpResourceActor(resourceContext: ResourceContext)
    * These will be matched against the `Content-Type` header of incoming requests.
    * @return a list of content types
    */
-  val acceptableContentTypes: List[ContentType] = List(ContentTypes.`application/json`)
+  val acceptableContentTypes: List[ContentType] = List(ContentTypes.`application/json`, ContentTypes.`application/json`.withoutDefinedCharset)
 
   /**
    * The content type that this server provides, by default `application/json`

--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/DummyResource.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/DummyResource.scala
@@ -51,10 +51,6 @@ class DummyResource(requestContext: ResourceContext)
   /** Default response content type is `text/plain` */
   override val responseContentType: ContentType = ContentTypes.`text/plain`
 
-  /** Default accepted content types are `application/json` and `text/plain` */
-  override val acceptableContentTypes: List[ContentType] =
-    List(ContentTypes.`application/json`, ContentTypes.`text/plain`)
-
   /**
    * A dummy GET request must have a query param "foo=bar" and an Accept header with a single value `text/plain`
    * @param req the request


### PR DESCRIPTION
Since spray [always renders JSON to UTF-8](https://github.com/spray/spray/blob/master/spray-http/src/main/scala/spray/http/ContentType.scala#L65-L66) they made their constant require UTF-8. But we should not be so restrictive. When the charset is not specified, UTF-8 is assumed. See [RFC 4627, section 3](https://www.ietf.org/rfc/rfc4627.txt).