### PR TITLE
update start method to take server settings

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
@@ -67,7 +67,7 @@ object SprayActor {
    */
   def start(systemWrapper: ActorSystemWrapper,
             sprayConfig: SprayConfiguration,
-            serverSettings: Option[ServerSettings])
+            serverSettings: Option[ServerSettings] = None)
            (implicit sslEngineProvider: ServerSSLEngineProvider,
             timeout: Timeout): Future[Http.Event] = {
     //used for AkkaIO(...)

--- a/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
@@ -17,6 +17,8 @@ package com.paypal.cascade.http.actor
 
 import java.util.concurrent.TimeUnit
 
+import spray.can.server.ServerSettings
+
 import scala.concurrent.Future
 
 import akka.actor.{Actor, Props}
@@ -64,7 +66,8 @@ object SprayActor {
    *         "starting and stopping" for details on failure modes
    */
   def start(systemWrapper: ActorSystemWrapper,
-            sprayConfig: SprayConfiguration)
+            sprayConfig: SprayConfiguration,
+            serverSettings: Option[ServerSettings])
            (implicit sslEngineProvider: ServerSSLEngineProvider,
             timeout: Timeout): Future[Http.Event] = {
     //used for AkkaIO(...)
@@ -75,7 +78,8 @@ object SprayActor {
     val bindMsg = Http.Bind(sprayActor,
       interface = "0.0.0.0",
       port = sprayConfig.port,
-      backlog = sprayConfig.backlog)
+      backlog = sprayConfig.backlog,
+      settings = serverSettings)
     (AkkaIO(Http) ? bindMsg).mapTo[Http.Event]
   }
 }

--- a/http/src/test/scala/com/paypal/cascade/http/tests/actor/SprayActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/actor/SprayActorSpecs.scala
@@ -54,7 +54,7 @@ class SprayActorSpecs
     import spray.can._
     def ok() = apply {
       //do this to make sure no exceptions on startup
-      val fut = SprayActor.start(wrapper, config, serverSettings = None)(mock[ServerSSLEngineProvider], timeout)
+      val fut = SprayActor.start(wrapper, config)(mock[ServerSSLEngineProvider], timeout)
       Await.result(fut, timeout.duration) must beAnInstanceOf[Http.Bound]
     }
   }

--- a/http/src/test/scala/com/paypal/cascade/http/tests/actor/SprayActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/actor/SprayActorSpecs.scala
@@ -54,7 +54,7 @@ class SprayActorSpecs
     import spray.can._
     def ok() = apply {
       //do this to make sure no exceptions on startup
-      val fut = SprayActor.start(wrapper, config)(mock[ServerSSLEngineProvider], timeout)
+      val fut = SprayActor.start(wrapper, config, serverSettings = None)(mock[ServerSSLEngineProvider], timeout)
       Await.result(fut, timeout.duration) must beAnInstanceOf[Http.Bound]
     }
   }


### PR DESCRIPTION
This is so optional server settings can be passed if multiple services are to be started with different configs.