### PR TITLE
Make before() and after() return Try[Unit] instead of Unit

### DIFF
--- a/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
+++ b/http/src/test/scala/com/paypal/cascade/http/tests/resource/HttpResourceActorSpecs.scala
@@ -236,10 +236,10 @@ class HttpResourceActorSpecs
     val afterLatch = new CountDownLatch(1)
 
     class WithBeforeAfter(ctx: ResourceContext) extends DummyResource(ctx) {
-      override def before(method: HttpMethod): Unit = {
+      override def before(method: HttpMethod): Try[Unit] = Try {
         beforeLatch.countDown()
       }
-      override def after(resp: HttpResponse): Unit = {
+      override def after(resp: HttpResponse): Try[Unit] = Try {
         afterLatch.countDown()
       }
     }


### PR DESCRIPTION
I believe this helps to convey intent to the user and encourages good design. We noticed a few rare `NullPointerException`s which occurred because some `var` which should have been set in a `before()` was not set because `before()` had thrown an exception. This forces the user to at least wrap their code in a `Try`, which hopefully encourages them to consider what they should do in an exceptional case.