### PR TITLE
Fix BuildProperties

### DIFF
--- a/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
@@ -25,15 +25,10 @@ import com.paypal.cascade.common.logging.LoggingSugar
  *
  */
 class BuildProperties(propertiesFilePath: String = "/build.properties") extends LoggingSugar {
-
-  /**
-   * A new default properties file location, at `build.properties`, or None if no resource exists with that name
-   */
-  private val buildUrl = Option(getClass.getResource(propertiesFilePath))
-
+  
   // at first use, try to retrieve a Properties object
   private lazy val props: Option[Properties] = {
-    buildUrl.flatMap { url =>
+    Option(getClass.getResource(propertiesFilePath)).flatMap { url =>
       try {
         val stream = url.openStream()
         val p = new Properties

--- a/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
@@ -22,13 +22,15 @@ import com.paypal.cascade.common.logging.LoggingSugar
 
 /**
  * Class specifically for accessing values from build.properties.
- *
+ * @param propertiesResourcePath the path to the .properties resource file. See
+ *   <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/Class.html#getResource%28java.lang.String%29">here</a>
+ *   for more information on how to pass this argument.
  */
-class BuildProperties(propertiesFilePath: String = "/build.properties") extends LoggingSugar {
+class BuildProperties(propertiesResourcePath: String = "/build.properties") extends LoggingSugar {
 
   // at first use, try to retrieve a Properties object
   private lazy val props: Option[Properties] = {
-    Option(getClass.getResource(propertiesFilePath)).flatMap { url =>
+    Option(getClass.getResource(propertiesResourcePath)).flatMap { url =>
       try {
         val stream = url.openStream()
         val p = new Properties
@@ -40,14 +42,14 @@ class BuildProperties(propertiesFilePath: String = "/build.properties") extends 
         }
       } catch {
         case ioe: IOException =>
-          getLogger[BuildProperties].warn(s"Unable to load $propertiesFilePath", ioe)
+          getLogger[BuildProperties].warn(s"Unable to load $propertiesResourcePath", ioe)
           None
       }
     }
   }
 
   /**
-   * Retrieves an optional value from a `java.util.Properties` object
+   * Retrieves an optional value from a lazily-loaded `java.util.Properties` object.
    * @param key the key to retrieve
    * @return an optional String value for the given `key`
    */

--- a/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
@@ -28,7 +28,7 @@ class BuildProperties extends LoggingSugar {
   /**
    * A new default properties file location, at `build.properties`, or None if no resource exists with that name
    */
-  private val buildUrl = Try(getClass.getResource("/build.properties")).toOption
+  private val buildUrl = Option(getClass.getResource("/build.properties"))
 
   // at first use, try to retrieve a Properties object
   private lazy val props: Option[Properties] = {

--- a/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
@@ -24,12 +24,12 @@ import com.paypal.cascade.common.logging.LoggingSugar
  * Class specifically for accessing values from build.properties.
  *
  */
-class BuildProperties extends LoggingSugar {
+class BuildProperties(propertiesFilePath: String = "/build.properties") extends LoggingSugar {
 
   /**
    * A new default properties file location, at `build.properties`, or None if no resource exists with that name
    */
-  private val buildUrl = Option(getClass.getResource("/build.properties"))
+  private val buildUrl = Option(getClass.getResource(propertiesFilePath))
 
   // at first use, try to retrieve a Properties object
   private lazy val props: Option[Properties] = {
@@ -45,7 +45,7 @@ class BuildProperties extends LoggingSugar {
         }
       } catch {
         case ioe: IOException =>
-          getLogger[BuildProperties].warn("Unable to load build.properties", ioe)
+          getLogger[BuildProperties].warn(s"Unable to load $propertiesFilePath", ioe)
           None
       }
     }

--- a/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
+++ b/common/src/main/scala/com/paypal/cascade/common/properties/BuildProperties.scala
@@ -25,7 +25,7 @@ import com.paypal.cascade.common.logging.LoggingSugar
  *
  */
 class BuildProperties(propertiesFilePath: String = "/build.properties") extends LoggingSugar {
-  
+
   // at first use, try to retrieve a Properties object
   private lazy val props: Option[Properties] = {
     Option(getClass.getResource(propertiesFilePath)).flatMap { url =>

--- a/common/src/test/resources/test_build.properties
+++ b/common/src/test/resources/test_build.properties
@@ -1,0 +1,1 @@
+test=foo

--- a/common/src/test/scala/com/paypal/cascade/common/tests/properties/BuildPropertiesSpecs.scala
+++ b/common/src/test/scala/com/paypal/cascade/common/tests/properties/BuildPropertiesSpecs.scala
@@ -34,11 +34,7 @@ class BuildPropertiesSpecs extends Specification { override def is = s2"""
 
   """
 
-  trait Context extends CommonImmutableSpecificationContext {
-    // Nothing for now
-  }
-
-  case class GetValue() extends Context {
+  case class GetValue() extends CommonImmutableSpecificationContext {
     def ok = apply {
       val bp = new BuildProperties("/test_build.properties")
       bp.get("test") must beSome("foo")

--- a/common/src/test/scala/com/paypal/cascade/common/tests/properties/BuildPropertiesSpecs.scala
+++ b/common/src/test/scala/com/paypal/cascade/common/tests/properties/BuildPropertiesSpecs.scala
@@ -28,7 +28,9 @@ class BuildPropertiesSpecs extends Specification { override def is = s2"""
   BuildProperties loads the build.properties files.
 
   Get should:
-    get the value when the path exists      ${GetValue().ok}
+    get the value when the it's in the file               ${GetValue().ok}
+    return None when the value isn't in the file          ${GetValue().notInFile}
+    return None when the file wasn't loaded               ${GetValue().fileNotLoaded}
 
   """
 
@@ -40,6 +42,16 @@ class BuildPropertiesSpecs extends Specification { override def is = s2"""
     def ok = apply {
       val bp = new BuildProperties("/test_build.properties")
       bp.get("test") must beSome("foo")
+    }
+
+    def notInFile = apply {
+      val bp = new BuildProperties("/test_build.properties")
+      bp.get("not.in.file") must beNone
+    }
+
+    def fileNotLoaded = apply {
+      val bp = new BuildProperties("/not.a.file")
+      bp.get("test") must beNone
     }
   }
 

--- a/common/src/test/scala/com/paypal/cascade/common/tests/properties/BuildPropertiesSpecs.scala
+++ b/common/src/test/scala/com/paypal/cascade/common/tests/properties/BuildPropertiesSpecs.scala
@@ -16,14 +16,14 @@
 package com.paypal.cascade.common.tests.properties
 
 import org.specs2._
-import org.specs2.mock.Mockito
-import com.paypal.cascade.common.tests.util.CommonImmutableSpecificationContext
+
 import com.paypal.cascade.common.properties.BuildProperties
+import com.paypal.cascade.common.tests.util.CommonImmutableSpecificationContext
 
 /**
  * Tests [[com.paypal.cascade.common.properties.BuildProperties]]
  */
-class BuildPropertiesSpecs extends Specification with Mockito { override def is = s2"""
+class BuildPropertiesSpecs extends Specification { override def is = s2"""
 
   BuildProperties loads the build.properties files.
 
@@ -38,9 +38,8 @@ class BuildPropertiesSpecs extends Specification with Mockito { override def is 
 
   case class GetValue() extends Context {
     def ok = apply {
-      val bp = spy(new BuildProperties)
-      bp.get("some.property") returns Some("somevalue")
-      bp.get("some.property") must beSome("somevalue")
+      val bp = new BuildProperties("/test_build.properties")
+      bp.get("test") must beSome("foo")
     }
   }
 


### PR DESCRIPTION
* Fixes #134 by using the primitive `try`/`finally` construct
* Fixes another bug where a `Some(null)` could be created. Please don't use `.toOption`.
* Lets `BuildProperties` be constructed with a different resource path in case downstream users have different project structures. Bonus effect: made it much easier to test.
* Oh, by the way, the test for this class actually tests something now instead of just making itself pass with Mockito. While the sweet minty taste is compelling, we do have to actually test the code.
* Other cleanup.