### PR TITLE
Bump jackson to 2.5.3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -157,7 +157,7 @@ object BuildSettings {
 object Dependencies {
 
   val slf4jVersion = "1.7.10"
-  val fasterXmlJacksonVersion = "2.4.4"
+  val fasterXmlJacksonVersion = "2.5.3"
   val sprayVersion = "1.3.3"
   val akkaVersion = "2.3.9"
   val parboiledVersion = "1.1.7"
@@ -166,7 +166,7 @@ object Dependencies {
   lazy val logback             = "ch.qos.logback"                 %  "logback-classic"       % "1.1.2" exclude("org.slf4j", "slf4j-api")
 
   lazy val jacksonDataBind     = "com.fasterxml.jackson.core"     %  "jackson-databind"      % fasterXmlJacksonVersion exclude("com.fasterxml.jackson.core", "jackson-annotations")
-  lazy val jacksonScalaModule  = "com.fasterxml.jackson.module"   %% "jackson-module-scala"  % fasterXmlJacksonVersion exclude("com.fasterxml.jackson.core", "jackson-databind")
+  lazy val jacksonScalaModule  = "com.fasterxml.jackson.module"   %% "jackson-module-scala"  % "2.5.2" /* fix later */ exclude("com.fasterxml.jackson.core", "jackson-databind") exclude("com.fasterxml.jackson.core", "jackson-core")
   lazy val jacksonJodaModule   = "com.fasterxml.jackson.datatype" %  "jackson-datatype-joda" % fasterXmlJacksonVersion exclude("com.fasterxml.jackson.core", "jackson-annotations") exclude("com.fasterxml.jackson.core", "jackson-core") exclude("com.fasterxml.jackson.core", "jackson-databind")
   lazy val jodaConvert         = "org.joda"                       %  "joda-convert"          % "1.2"
 


### PR DESCRIPTION
The scala module for jackson is still at 2.5.2, so I added an exclusion rule for it.

I also looked into using jackson 2.5.2 but hilariously jackson-databind 2.5.2 relies on jackson-core 2.5.1, so I wasn't about to let that nonsense in.