### PR TITLE
Added support for custom exception handlers and created a default

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/server/CascadeExceptionHandler.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/server/CascadeExceptionHandler.scala
@@ -1,0 +1,15 @@
+package com.paypal.cascade.http.server
+
+import spray.http.Language
+import spray.routing.ExceptionHandler
+
+import com.paypal.cascade.http.util.HttpErrorResponeHandler
+
+object CascadeExceptionHandler extends HttpErrorResponeHandler {
+  val responseLanguage: Option[Language] = Option(Language("en", "US"))
+
+  val handler = ExceptionHandler {
+    case e: Exception => ctx => createErrorResponse(e, ctx.request, responseLanguage)
+    case t: Throwable => ctx => throw t
+  }
+}

--- a/http/src/main/scala/com/paypal/cascade/http/server/SprayConfiguration.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/server/SprayConfiguration.scala
@@ -15,7 +15,7 @@
  */
 package com.paypal.cascade.http.server
 
-import spray.routing.{RejectionHandler, Route}
+import spray.routing.{ExceptionHandler, RejectionHandler, Route}
 
 /**
  * This class provides configuration information for a spray service
@@ -24,11 +24,12 @@ class SprayConfiguration(val serviceName: String,
                          val port: Int,
                          val backlog: Int,
                          val route: Route,
+                         val customExceptionHandler: Option[ExceptionHandler] = None,
                          val customRejectionHandler: Option[RejectionHandler] = None)
 
 object SprayConfiguration {
-  def apply(serviceName: String, port: Int, backlog: Int, customRejectionHandler: Option[RejectionHandler] = None)
+  def apply(serviceName: String, port: Int, backlog: Int, customExceptionHandler: Option[ExceptionHandler] = None, customRejectionHandler: Option[RejectionHandler] = None)
            (route: Route): SprayConfiguration = {
-    new SprayConfiguration(serviceName, port, backlog, route, customRejectionHandler)
+    new SprayConfiguration(serviceName, port, backlog, route, customExceptionHandler, customRejectionHandler)
   }
 }

--- a/http/src/main/scala/com/paypal/cascade/http/util/HttpErrorResponeHandler.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/util/HttpErrorResponeHandler.scala
@@ -1,0 +1,70 @@
+package com.paypal.cascade.http.util
+
+import java.nio.charset.StandardCharsets._
+
+import spray.http.HttpEntity.NonEmpty
+import spray.http.HttpHeaders.{RawHeader, `WWW-Authenticate`}
+import spray.http.StatusCodes._
+import spray.http._
+
+import com.paypal.cascade.common.logging.LoggingSugar
+import com.paypal.cascade.http.resource.HaltException
+
+trait HttpErrorResponeHandler extends LoggingSugar {
+
+  private[this] val log = getLogger[HttpErrorResponeHandler]
+
+  /**
+   * Creates an appropriate HttpResponse for a given exception, request, and response language.
+   *
+   * @param exception the exception
+   * @param request the request
+   * @param responseLanguage option of language to make the response
+   * @return a crafted HttpResponse from the error message
+   */
+  def createErrorResponse(exception: Exception, request: HttpRequest, responseLanguage: Option[Language]): HttpResponse = {
+    val resp = exception match {
+      case haltException: HaltException =>
+        val response = addHeaderOnCode(haltException.response, Unauthorized) {
+          `WWW-Authenticate`(HttpUtil.unauthorizedChallenge(request))
+        }
+        // If the error already has the right content type, let it through, otherwise coerce it
+        val finalResponse = response.withEntity(response.entity.flatMap {
+          entity: NonEmpty =>
+            entity.contentType match {
+              case HttpUtil.errorResponseType => entity
+              case _ => HttpUtil.toJsonBody(entity.data.asString(UTF_8))
+            }
+        })
+        if (finalResponse.status.intValue >= 500) {
+          val statusCode = finalResponse.status.intValue
+          log.warn(s"Request finished unsuccessfully with status code: $statusCode")
+        }
+        finalResponse
+      case otherException: Exception =>
+        HttpResponse(InternalServerError, HttpUtil.toJsonBody(s"Error in request execution: ${otherException.getClass.getSimpleName}"))
+    }
+    resp.withHeaders(addLanguageHeader(responseLanguage, resp.headers))
+  }
+
+  private[cascade] def addHeaderOnCode(response: HttpResponse, status: StatusCode)
+                                      (header: => HttpHeader): HttpResponse = {
+    if(response.status == status) {
+      response.withHeaders(header :: response.headers)
+    } else {
+      response
+    }
+  }
+
+  private[cascade] def addLanguageHeader(responseLanguage: Option[Language], headers: List[HttpHeader]) : List[HttpHeader] = {
+    responseLanguage match {
+      case Some(lang) =>
+        if (headers.exists(_.lowercaseName == HttpUtil.CONTENT_LANGUAGE_LC)) {
+          headers
+        } else {
+          RawHeader(HttpUtil.CONTENT_LANGUAGE, lang.toString) :: headers
+        }
+      case None => headers
+    }
+  }
+}


### PR DESCRIPTION
There is two main things done here 
1. Support for a custom exception handler specified in the SprayConfiguration has been added.  This will be used if given.
2. A CascadeExceptionHandler was created to act as the default handler instead of using the implicit one to give improved errors even when a handler is not given.

The only API/signature to change was the SprayConfiguration where an optional parameter with a default of None was added to pass the custom exception handler.  All other APIs/signatures should show the same behavior.

Most of the changes were moved code for reuse purposes so that the same error message handling could be used both in context of an actor and in context of routing.