### PR TITLE
Add support for giving a custom exception handler

### DIFF
--- a/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/actor/SprayActor.scala
@@ -38,8 +38,14 @@ import com.paypal.cascade.http.server.{CascadeRejectionHandler, SprayConfigurati
 class SprayActor(override val sprayConfig: SprayConfiguration,
                  override val actorSystemWrapper: ActorSystemWrapper) extends Actor with ResourceService {
   //lifting implicits so we can pass them explicitly to runRoute below
-  private[this] val exceptionHandler = implicitly[ExceptionHandler]
   private[this] val routingSettings = implicitly[RoutingSettings]
+
+  private val exceptionHandler = {
+    sprayConfig.customExceptionHandler match {
+      case Some(handler) => handler.orElse(implicitly[ExceptionHandler])
+      case None => implicitly[ExceptionHandler]
+    }
+  }
 
   private val rejectionHandler = {
     sprayConfig.customRejectionHandler match {

--- a/http/src/main/scala/com/paypal/cascade/http/server/SprayConfiguration.scala
+++ b/http/src/main/scala/com/paypal/cascade/http/server/SprayConfiguration.scala
@@ -15,7 +15,7 @@
  */
 package com.paypal.cascade.http.server
 
-import spray.routing.{RejectionHandler, Route}
+import spray.routing.{ExceptionHandler, RejectionHandler, Route}
 
 /**
  * This class provides configuration information for a spray service
@@ -24,11 +24,12 @@ class SprayConfiguration(val serviceName: String,
                          val port: Int,
                          val backlog: Int,
                          val route: Route,
+                         val customExceptionHandler: Option[ExceptionHandler] = None,
                          val customRejectionHandler: Option[RejectionHandler] = None)
 
 object SprayConfiguration {
-  def apply(serviceName: String, port: Int, backlog: Int, customRejectionHandler: Option[RejectionHandler] = None)
+  def apply(serviceName: String, port: Int, backlog: Int, customExceptionHandler: Option[ExceptionHandler] = None, customRejectionHandler: Option[RejectionHandler] = None)
            (route: Route): SprayConfiguration = {
-    new SprayConfiguration(serviceName, port, backlog, route, customRejectionHandler)
+    new SprayConfiguration(serviceName, port, backlog, route, customExceptionHandler, customRejectionHandler)
   }
 }


### PR DESCRIPTION
This is a simple addition of giving a custom ExceptionHandler to the SprayConfiguration to allow a custom one to be set for the SprayActor.  This is a missing feature that allowing it to be overwritten allows nicer failure messages to be returned on exceptions.